### PR TITLE
Switch frontend to use Docker

### DIFF
--- a/bin/router.php
+++ b/bin/router.php
@@ -15,7 +15,7 @@ else {
     // Issue a redirect rather than rewrite because other servers won't assume
     // index.twig.html is an index file and we don't want to encourage
     // <a href="/"… in page files.
-    $indexes = ['/index.twig.html', '/index.php.html'];
+    $indexes = ['index.php', '/index.twig.html', '/index.php.html'];
     foreach ($indexes as $index) {
       if (file_exists($docroot . $page . $index)) {
         $page = rtrim($page, '/');
@@ -27,8 +27,22 @@ else {
   }
 
   if (!is_file($docroot . $page)) {
+    if ($page == '/') {
+      // Top level homepage - then just send them to the pages directory which is probably a good place to start.
+      http_response_code(302);
+      header("location: /pages");
+      exit;
+    }
+
     http_response_code(404);
     print '<h1>404 Not Found</h1>';
+    print "<ul>";
+    print "<li>Could not find {$docroot}{$page}</li>";
+    print "<li>Docroot: {$docroot}</li>";
+    print "<li>Page: {$page}</li>";
+    print "</ul>";
+    print "<pre>";
+    var_dump($_ENV);
     exit;
   }
 }

--- a/bin/start.sh
+++ b/bin/start.sh
@@ -1,54 +1,16 @@
 #!/bin/bash
 
-PHPCMD='php -S 127.0.0.1:3000 ./node_modules/.bin/deeson-router-php'
 WEBPACKCMD='./node_modules/deeson-webpack-config-starter/node_modules/.bin/webpack-dev-server'
 
 if [ ! -f $WEBPACKCMD ]; then
   WEBPACKCMD='./node_modules/.bin/webpack-dev-server'
 fi
 
-PIDS=$(lsof -t -i tcp:3000 -i tcp:8080 -s tcp:LISTEN)
-CPIDS=$(echo $PIDS | tr " " ",")
-SPIDS=$(echo $PIDS | tr " " " ")
-
-if [[ ! -z $CPIDS ]]; then
-  WD=$(lsof -a -p $CPIDS -d cwd -F n | grep '^n' | cut -c 2- | uniq)
-  THIS="another"
-
-  if [ $(pwd) == "$WD" ]; then
-    THIS="this"
-  fi
-
-  echo -e "\033[93m\033[1mIt looks like you already have a frontend build going on in $THIS directory ($WD)."
-  read -r -n 1 -p "We cant run two at once, would you like the other one stopped? [y/n] " response
-
-  case $response in
-    y)
-      echo -e "\n.. stopping"
-      kill -KILL $SPIDS
-      ;;
-    *)
-      echo -e "\n.. cancelled"
-      exit
-      ;;
-  esac
-
-  echo -e "\033[0m"
-fi
-
-
-$PHPCMD &
-PHP=$!
+WEBPACKCMD="${WEBPACKCMD}"
 
 $WEBPACKCMD &
 WP=$!
 
-trap "kill -KILL $PHP $WP > /dev/null 2>&1" EXIT
+echo -e '\n\033[32m\033[1mEverything up and running at http://frontend.localhost/webpack-dev-server -- Ctrl-C to quit\033[0m\n';
 
-if ! lsof -t -p $PHP || ! lsof -t -p $WP; then
-  echo -e '\033[1m\033[31mSomething failed to start, take a note of the errors above and give james a shout.\033[0m';
-else
-  echo -e '\n\033[32m\033[1mEverything up and running at https://localhost:8080/<your page> -- Ctrl-C to quit\033[0m\n';
-fi
-
-wait $PHP $WP > /dev/null 2>&1
+wait $WP > /dev/null 2>&1

--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ const config = {
     inline: true,
     quiet: false,
     noInfo: false,
-    https: true,
+    https: false,
     stats: {
       assets: false,
       colors: true,
@@ -34,7 +34,7 @@ const config = {
     },
     proxy: {
       '*': {
-        target: 'http://localhost:3000',
+        target: 'http://fe-php',
         secure: false,
       },
     },

--- a/index.js
+++ b/index.js
@@ -23,6 +23,8 @@ const config = {
     quiet: false,
     noInfo: false,
     https: false,
+    host: "0.0.0.0",
+    port: 80,
     stats: {
       assets: false,
       colors: true,

--- a/index.js
+++ b/index.js
@@ -25,6 +25,7 @@ const config = {
     https: false,
     host: "0.0.0.0",
     port: 80,
+    disableHostCheck: true,
     stats: {
       assets: false,
       colors: true,


### PR DESCRIPTION
Hi, I'd like for frontend to use Docker for the node and php related tasks it performs. I've had a crack at breaking up the config project so that it expects PHP to be elsewhere. This means that its doing less than it was, but also means everything is more opinionated - we kind of expect this framework to be used with our d8-quickstart and with docker as we configure it.