### PR TITLE
Remove image-webpack-loader package

### DIFF
--- a/index.js
+++ b/index.js
@@ -76,14 +76,6 @@ const config = {
               context: 'src',
             },
           },
-          {
-            loader: 'image-webpack-loader',
-            options: {
-              pngquant: { quality: '65-90', speed: 4 },
-              mozjpeg: { progressive: true },
-              gifsicle: { interlaced: false },
-            },
-          },
         ],
       },
       {
@@ -95,14 +87,6 @@ const config = {
             options: {
               name: '[path][name].[ext]',
               context: 'src',
-            },
-          },
-          {
-            loader: 'image-webpack-loader',
-            options: {
-              pngquant: { quality: '65-90', speed: 4 },
-              mozjpeg: { progressive: true },
-              gifsicle: { interlaced: false },
             },
           },
         ],

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "extract-text-webpack-plugin": "^2.1.0",
     "file-loader": "^0.9.0",
     "ignore-loader": "^0.1.2",
-    "image-webpack-loader": "^3.1.0",
     "imports-loader": "^0.7.0",
     "jest": "^19.0.2",
     "jquery": "^3.1.1",


### PR DESCRIPTION
image-webpack-loader uses mozjpeg and pngquant native binaries which are not compatible with our build system.

Projects work around this at present by overriding this config to remove the image-webpack-loader reference but we should just remove it here for simplicity.